### PR TITLE
Updated Faraday gem

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,2 +1,0 @@
---color
---format progress

--- a/expedia.gemspec
+++ b/expedia.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/zaidakram/expedia"
 
   spec.add_dependency "multi_json", "~> 1.3"
-  spec.add_dependency "faraday", "~> 0.8"
+  spec.add_dependency "faraday", "~> 1.3"
   spec.add_development_dependency "rspec", "~> 2.8"
   spec.add_development_dependency "rake", "~> 0.8"
 

--- a/expedia.gemspec
+++ b/expedia.gemspec
@@ -3,26 +3,21 @@ lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'expedia/version'
 
-Gem::Specification.new do |gem|
-  gem.name          = "expedia"
-  gem.version       = Expedia::VERSION
-  gem.platform      = Gem::Platform::RUBY
-  gem.authors       = ["Zaid Akram"]
-  gem.email         = ["zaidakrammughal@gmail.com"]
-  gem.licenses      = ["MIT"]
-  gem.description   = "Expedia is a lightweight, flexible Ruby SDK for EAN. It allows read/write access to the EAN APIs."
-  gem.summary       = "Expedia is a ruby wrapper for 'EAN (Expedia Affiliate Network)'"
-  gem.homepage      = "https://github.com/zaidakram/expedia"
+Gem::Specification.new do |spec|
+  spec.name          = "expedia"
+  spec.version       = Expedia::VERSION
+  spec.platform      = Gem::Platform::RUBY
+  spec.authors       = ["Zaid Akram"]
+  spec.email         = ["zaidakrammughal@gmail.com"]
+  spec.licenses      = ["MIT"]
+  spec.description   = "Expedia is a lightweight, flexible Ruby SDK for EAN. It allows read/write access to the EAN APIs."
+  spec.summary       = "Expedia is a ruby wrapper for 'EAN (Expedia Affiliate Network)'"
+  spec.homepage      = "https://github.com/zaidakram/expedia"
 
-  gem.files         = `git ls-files`.split($/)
-  gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
-  gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
-  gem.require_paths = ["lib"]
+  spec.add_dependency "multi_json", "~> 1.3"
+  spec.add_dependency "faraday", "~> 0.8"
+  spec.add_development_dependency "rspec", "~> 2.8"
+  spec.add_development_dependency "rake", "~> 0.8"
 
-  gem.add_runtime_dependency(%q<multi_json>,    ["~> 1.3"])
-  gem.add_runtime_dependency(%q<faraday>,       ["~> 0.8"])
-  gem.add_development_dependency(%q<rspec>,     ["~> 2.8"])
-  gem.add_development_dependency(%q<rake>,      ["~> 0.8"])
-
-  
+  spec.require_paths = ["lib"]
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,6 +6,8 @@ require 'expedia'
 #
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 RSpec.configure do |config|
+  config.color = true
+  config.formatter = ENV["CI"] == "true" ? :progress : :documentation
   config.treat_symbols_as_metadata_keys_with_true_values = true
   config.run_all_when_everything_filtered = true
   config.filter_run :focus


### PR DESCRIPTION
## Overview

Updated to Faraday 1.3.0 because we need this support in order to update to the Sentry SDK gem on the HE API project.

## Details

- See commits for details.

## Notes

I'm not sure how reliable the specs are but they passed before and after I made these changes.